### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/174/967/421174967.geojson
+++ b/data/421/174/967/421174967.geojson
@@ -720,6 +720,9 @@
     },
     "wof:country":"AZ",
     "wof:created":1459009050,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c36c43cd4bef8c2bcbae7a886357cde9",
     "wof:hierarchy":[
         {
@@ -731,7 +734,7 @@
         }
     ],
     "wof:id":421174967,
-    "wof:lastmodified":1566603995,
+    "wof:lastmodified":1582332213,
     "wof:name":"Baku",
     "wof:parent_id":85668249,
     "wof:placetype":"locality",

--- a/data/856/327/17/85632717.geojson
+++ b/data/856/327/17/85632717.geojson
@@ -1204,6 +1204,11 @@
     },
     "wof:country":"AZ",
     "wof:country_alpha3":"AZE",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6",
+        "meso"
+    ],
     "wof:geomhash":"e236b7ee2ed5ce4dd8c2ced7a2167ca5",
     "wof:hierarchy":[
         {
@@ -1218,7 +1223,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"Azerbaijan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/681/95/85668195.geojson
+++ b/data/856/681/95/85668195.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Agstafa District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"04406e14d5789d6cf035693ee070da93",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"A\u011fstafa",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/681/99/85668199.geojson
+++ b/data/856/681/99/85668199.geojson
@@ -226,6 +226,9 @@
         "wd:id":"Q2332472"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8297dca387adbeedf38c62bdfe807ba",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"Da\u015fk\u0259s\u0259n",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/05/85668205.geojson
+++ b/data/856/682/05/85668205.geojson
@@ -229,6 +229,9 @@
         "wd:id":"Q2352160"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3f65599b04771c46ab4c642f00f7634f",
     "wof:hierarchy":[
         {
@@ -245,7 +248,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"G\u0259d\u0259b\u0259y",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/09/85668209.geojson
+++ b/data/856/682/09/85668209.geojson
@@ -143,6 +143,9 @@
         "qs_pg:id":420489
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8656e09464062aabea981378dae34c5",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"G\u0259nc\u0259",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/11/85668211.geojson
+++ b/data/856/682/11/85668211.geojson
@@ -254,6 +254,9 @@
         "wk:page":"Goygol District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"74ac4a6442a786ce54e147623fa0fed9",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"Xanlar",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/15/85668215.geojson
+++ b/data/856/682/15/85668215.geojson
@@ -234,6 +234,9 @@
         "wk:page":"Goranboy District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ab5632eb974d64b9d8effb786739c78",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332204,
     "wof:name":"Goranboy",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/21/85668221.geojson
+++ b/data/856/682/21/85668221.geojson
@@ -148,6 +148,9 @@
         "qs_pg:id":245251
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b64299c7c423fd4862f495e23d3cf5a",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"K\u0259lb\u0259c\u0259r",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/682/25/85668225.geojson
+++ b/data/856/682/25/85668225.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":1015437
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e68786e02076af9e9b5abe347f5c1dc1",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332205,
     "wof:name":"Ming\u0259\u00e7evir",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/29/85668229.geojson
+++ b/data/856/682/29/85668229.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Qazakh District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"119a119e75dd800bb34e6002f8ed1266",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"Qazax",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/33/85668233.geojson
+++ b/data/856/682/33/85668233.geojson
@@ -292,6 +292,9 @@
         "wd:id":"Q390783"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"106a481a1310c4af0229003e792bf9d5",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"\u015e\u0259mkir",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/35/85668235.geojson
+++ b/data/856/682/35/85668235.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Samukh District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f8fc1f83438f6038e4af4f769d7d10ea",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"Samux",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/41/85668241.geojson
+++ b/data/856/682/41/85668241.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Tovuz District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0733d0a0e34218a66edd8de241c825e",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332204,
     "wof:name":"Tovuz",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/43/85668243.geojson
+++ b/data/856/682/43/85668243.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Yevlakh District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d8b7fc86687c1c0ac8ff8a901f9b4296",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"Yevlakh Rayon",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/49/85668249.geojson
+++ b/data/856/682/49/85668249.geojson
@@ -693,6 +693,9 @@
         "wk:page":"Baku"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b04a68d7055e3d3ba6fc9956510bec6",
     "wof:hierarchy":[
         {
@@ -709,7 +712,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332205,
     "wof:name":"Bak\u0131",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/682/51/85668251.geojson
+++ b/data/856/682/51/85668251.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Absheron District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"498655f45c2a984987c0b90b704eb226",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"Ab\u015feron",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/682/57/85668257.geojson
+++ b/data/856/682/57/85668257.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Agdam District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"43e5bc9ab1d4640b2fd6122b0fcde60a",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"A\u011fdam",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/682/59/85668259.geojson
+++ b/data/856/682/59/85668259.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Agdash District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"67d16f75e97163f9494d26e4a38c7159",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"A\u011fda\u015f",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/89/85668289.geojson
+++ b/data/856/682/89/85668289.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Agsu District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ec4cd851a56626fe8001bc9e320d0b1",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"A\u011fsu",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/682/93/85668293.geojson
+++ b/data/856/682/93/85668293.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"AZ-HAC"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0053cfef8aa9e02b806115ec92a3fff",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603766,
+    "wof:lastmodified":1582332204,
     "wof:name":"Hajigabul",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/97/85668297.geojson
+++ b/data/856/682/97/85668297.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Astara District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bd9d55b607a0ff69d0c531d87cec2268",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603767,
+    "wof:lastmodified":1582332204,
     "wof:name":"Astara",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/03/85668303.geojson
+++ b/data/856/683/03/85668303.geojson
@@ -143,6 +143,9 @@
         "qs_pg:id":66061
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a40b796341218830098048280541e338",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332206,
     "wof:name":"B\u0259rd\u0259",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/13/85668313.geojson
+++ b/data/856/683/13/85668313.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":128258
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2d3c71dbc231ad3602c60b28e5223e48",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"Beyl\u0259qan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/17/85668317.geojson
+++ b/data/856/683/17/85668317.geojson
@@ -215,6 +215,9 @@
         "qs_pg:id":1092313
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"effe44b0655b1903fe835bc4ec852b17",
     "wof:hierarchy":[
         {
@@ -231,7 +234,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"Bil\u0259suvar",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/23/85668323.geojson
+++ b/data/856/683/23/85668323.geojson
@@ -148,6 +148,9 @@
         "qs_pg:id":1172844
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"423d1fd9d09da09ee51a7fd806c26bdf",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"C\u0259bray\u0131l",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/683/31/85668331.geojson
+++ b/data/856/683/31/85668331.geojson
@@ -285,6 +285,9 @@
         "wd:id":"Q1020627"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2b0de9f91cb20f17f052105e4baee57",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"C\u0259lilabad",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/39/85668339.geojson
+++ b/data/856/683/39/85668339.geojson
@@ -174,6 +174,9 @@
         "qs_pg:id":245519
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"201dfadf1ca60531d776dd41b66328d3",
     "wof:hierarchy":[
         {
@@ -190,7 +193,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"D\u0259v\u0259\u00e7i",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/683/51/85668351.geojson
+++ b/data/856/683/51/85668351.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Fuzuli District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a4a544db877e2774278a1180803634b",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"F\u00fczuli",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/683/57/85668357.geojson
+++ b/data/856/683/57/85668357.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Goychay District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a461ec59164516f040b99c65b6a1b38a",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"G\u00f6y\u00e7ay",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/65/85668365.geojson
+++ b/data/856/683/65/85668365.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Imishli District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb597941eb7183864bd9b699ef03e8a2",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"\u0130mi\u015fli",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/73/85668373.geojson
+++ b/data/856/683/73/85668373.geojson
@@ -231,6 +231,9 @@
         "wd:id":"Q2148072"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c6bc8674c02a763b07cd92b528b97e16",
     "wof:hierarchy":[
         {
@@ -247,7 +250,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"\u0130smay\u0131ll\u0131",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/683/83/85668383.geojson
+++ b/data/856/683/83/85668383.geojson
@@ -228,6 +228,9 @@
         "wd:id":"Q1851063"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c853406ca2a87200e385444a027c3b7f",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"K\u00fcrd\u0259mir",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/89/85668389.geojson
+++ b/data/856/683/89/85668389.geojson
@@ -260,6 +260,9 @@
         "qs_pg:id":245193
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d52e0f6333a8959ff8740a251c6fc52c",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603772,
+    "wof:lastmodified":1582332207,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/97/85668397.geojson
+++ b/data/856/683/97/85668397.geojson
@@ -248,6 +248,9 @@
         "wd:id":"Q512116"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"077c021699895e969f84336024196d69",
     "wof:hierarchy":[
         {
@@ -264,7 +267,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603773,
+    "wof:lastmodified":1582332207,
     "wof:name":"Masall\u0131",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/684/03/85668403.geojson
+++ b/data/856/684/03/85668403.geojson
@@ -282,6 +282,9 @@
         "wk:page":"Lerik District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e66ab46efd0c059c0f77766d3ca87347",
     "wof:hierarchy":[
         {
@@ -298,7 +301,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"Lerik",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/684/09/85668409.geojson
+++ b/data/856/684/09/85668409.geojson
@@ -285,6 +285,9 @@
         "wk:page":"Neftchala District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4aae6184e97715a4c0b4fbee6353aafe",
     "wof:hierarchy":[
         {
@@ -301,7 +304,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"Neft\u00e7ala",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/19/85668419.geojson
+++ b/data/856/684/19/85668419.geojson
@@ -288,6 +288,9 @@
         "wk:page":"Gobustan District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0e56a8b5a61a76b4ffeed07dd4431dbf",
     "wof:hierarchy":[
         {
@@ -304,7 +307,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"Qobustan",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/684/25/85668425.geojson
+++ b/data/856/684/25/85668425.geojson
@@ -221,6 +221,9 @@
         "qs_pg:id":270754
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bebd77e227d6b202962ec4dbbb09606c",
     "wof:hierarchy":[
         {
@@ -237,7 +240,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Siy\u0259z\u0259n",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/684/33/85668433.geojson
+++ b/data/856/684/33/85668433.geojson
@@ -155,6 +155,9 @@
         "unlc:id":"AZ-SAT"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"151873861990eb356adb73b9d7c6005e",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"Saatl\u0131",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/47/85668447.geojson
+++ b/data/856/684/47/85668447.geojson
@@ -231,6 +231,9 @@
         "wk:page":"Sabirabad District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"48fb319aab9775281b58dac6fdb75239",
     "wof:hierarchy":[
         {
@@ -247,7 +250,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Sabirabad",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/49/85668449.geojson
+++ b/data/856/684/49/85668449.geojson
@@ -292,6 +292,9 @@
         "wk:page":"Salyan District, Azerbaijan"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"07dbb34097d1fd9d6d500fd02e20ed9f",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Salyan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/59/85668459.geojson
+++ b/data/856/684/59/85668459.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"AZ-SMI"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e1d50b2ead31fbb3a5ee6b1c1dde329",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"\u015eamax\u0131",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/684/65/85668465.geojson
+++ b/data/856/684/65/85668465.geojson
@@ -375,6 +375,9 @@
         "wk:page":"Sumqayit"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"27c0ac67059bf0ec59611d78e98495ab",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Sumqay\u0131t",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/684/75/85668475.geojson
+++ b/data/856/684/75/85668475.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Ujar District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ede1c99bb237bfff2f20cc44c3bf5eff",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332206,
     "wof:name":"Ucar",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/85/85668485.geojson
+++ b/data/856/684/85/85668485.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"AZ-XIZ"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a02a29370317c132f76a8a15384e83c",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Xiz\u0131",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/684/97/85668497.geojson
+++ b/data/856/684/97/85668497.geojson
@@ -205,6 +205,9 @@
         "unlc:id":"AZ-YAR"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d3b02bf8c463c23fc3026cce90cb5c6d",
     "wof:hierarchy":[
         {
@@ -221,7 +224,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603771,
+    "wof:lastmodified":1582332206,
     "wof:name":"Yard\u0131ml\u0131",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/685/09/85668509.geojson
+++ b/data/856/685/09/85668509.geojson
@@ -143,6 +143,9 @@
         "qs_pg:id":128264
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0464b040f82397d7441689e9d338df61",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Z\u0259rdab",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/685/19/85668519.geojson
+++ b/data/856/685/19/85668519.geojson
@@ -247,6 +247,9 @@
         "wd:id":"Q1983875"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"224e785ce152adf7a1a598464c4f4416",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332205,
     "wof:name":"A\u011fcab\u0259di",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/685/31/85668531.geojson
+++ b/data/856/685/31/85668531.geojson
@@ -256,6 +256,9 @@
         "wd:id":"Q1989793"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69c662c66b76c172d1d68a15ed8d795e",
     "wof:hierarchy":[
         {
@@ -272,7 +275,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Balak\u0259n",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/41/85668541.geojson
+++ b/data/856/685/41/85668541.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":1061835
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5045c2d6674b9fb7c7c51c76ab13e32e",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Q\u0259b\u0259l\u0259",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/49/85668549.geojson
+++ b/data/856/685/49/85668549.geojson
@@ -296,6 +296,9 @@
         "wk:page":"Oghuz District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f2dd13223f93d6736b795aec00b8b5e",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603770,
+    "wof:lastmodified":1582332205,
     "wof:name":"O\u011fuz",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/57/85668557.geojson
+++ b/data/856/685/57/85668557.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"AZ-QAX"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3dfe61b347d1666d10f71e475bdb5e4d",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603768,
+    "wof:lastmodified":1582332205,
     "wof:name":"Qax",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/65/85668565.geojson
+++ b/data/856/685/65/85668565.geojson
@@ -82,6 +82,9 @@
         "qs_pg:id":32219
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8e0640f4c852fb205d04aba6793d7137",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"\u015e\u0259ki",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/71/85668571.geojson
+++ b/data/856/685/71/85668571.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Quba District (Azerbaijan)"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dc5b54b96c05cd6b15d99e58a7e6eb95",
     "wof:hierarchy":[
         {
@@ -316,7 +319,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Quba",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/685/77/85668577.geojson
+++ b/data/856/685/77/85668577.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Qusar District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8de7c517b5b868cb4f79b2c02bb86146",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Qusar",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/685/91/85668591.geojson
+++ b/data/856/685/91/85668591.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Khachmaz District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5fa28e4a76490433431a800ca4b6813",
     "wof:hierarchy":[
         {
@@ -310,7 +313,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603769,
+    "wof:lastmodified":1582332205,
     "wof:name":"Xa\u00e7maz",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/686/01/85668601.geojson
+++ b/data/856/686/01/85668601.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Zaqatala District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"44dded50c59300a85ec584cfe8c24417",
     "wof:hierarchy":[
         {
@@ -323,7 +326,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"Zaqatala",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/686/11/85668611.geojson
+++ b/data/856/686/11/85668611.geojson
@@ -150,6 +150,9 @@
         "qs_pg:id":59492
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"878a05236dc254ed3bd9a8af9332f401",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Xocav\u0259nd",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/21/85668621.geojson
+++ b/data/856/686/21/85668621.geojson
@@ -328,6 +328,9 @@
         "qs_pg:id":32221
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"62b5c1deedfdb5f9389a5b9f59e321b9",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332202,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/29/85668629.geojson
+++ b/data/856/686/29/85668629.geojson
@@ -142,6 +142,9 @@
         "unlc:id":"AZ-QBI"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"61b0cd6fb77089f305619a646848fb9c",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332202,
     "wof:name":"Qubadli",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/43/85668643.geojson
+++ b/data/856/686/43/85668643.geojson
@@ -236,6 +236,9 @@
         "wk:page":"Shusha District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8575ba81b3390c6936d20ed88c59ba6b",
     "wof:hierarchy":[
         {
@@ -252,7 +255,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332203,
     "wof:name":"\u015eu\u015fa",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/53/85668653.geojson
+++ b/data/856/686/53/85668653.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":245265
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b10cd5dc555f5734de44c6a88dfb1e43",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"T\u0259rt\u0259r",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/57/85668657.geojson
+++ b/data/856/686/57/85668657.geojson
@@ -154,6 +154,9 @@
         "unlc:id":"AZ-XCI"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53c4250cde4b8a6045be87b55c9eb8ce",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Xocal\u0131",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/59/85668659.geojson
+++ b/data/856/686/59/85668659.geojson
@@ -228,6 +228,9 @@
         "wd:id":"Q249226"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f144158a508b4ab13f204e621aeff03",
     "wof:hierarchy":[
         {
@@ -244,7 +247,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Z\u0259ngilan",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/63/85668663.geojson
+++ b/data/856/686/63/85668663.geojson
@@ -177,6 +177,9 @@
         "wd:id":"Q4404519"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2a8ec0088a209ad50dda77ea060c4b0",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"S\u0259d\u0259r\u0259k",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/65/85668665.geojson
+++ b/data/856/686/65/85668665.geojson
@@ -226,6 +226,9 @@
         "unlc:id":"AZ-ORD"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"06e53014022f9d26e1cf0bbba59b3d5e",
     "wof:hierarchy":[
         {
@@ -242,7 +245,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332203,
     "wof:name":"Ordubad",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/67/85668667.geojson
+++ b/data/856/686/67/85668667.geojson
@@ -218,6 +218,9 @@
         "wd:id":"Q162411"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f26c797af0ab8b78edae4dac858b6ccd",
     "wof:hierarchy":[
         {
@@ -234,7 +237,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"\u015e\u0259rur",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/73/85668673.geojson
+++ b/data/856/686/73/85668673.geojson
@@ -167,6 +167,9 @@
         "qs_pg:id":1191260
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"471172102bfef246d1a7d77207f5f2fc",
     "wof:hierarchy":[
         {
@@ -183,7 +186,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332202,
     "wof:name":"Bab\u0259k",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/77/85668677.geojson
+++ b/data/856/686/77/85668677.geojson
@@ -149,6 +149,9 @@
         "unlc:id":"AZ-CUL"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"583c3cb4d7fe92432bb2f8f057eb4bb4",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"Culfa",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/81/85668681.geojson
+++ b/data/856/686/81/85668681.geojson
@@ -338,6 +338,9 @@
         "wk:page":"Nakhchivan Autonomous Republic"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81512eb7d44e0803891588ddbfa0f90b",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332203,
     "wof:name":"Nax\u00e7\u0131van",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/83/85668683.geojson
+++ b/data/856/686/83/85668683.geojson
@@ -206,6 +206,9 @@
         "qs_pg:id":1191259
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68d52c52fc2eaa3007fba112042c1c1b",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"\u015eahbuz",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/91/85668691.geojson
+++ b/data/856/686/91/85668691.geojson
@@ -375,6 +375,9 @@
         "qs_pg:id":245328
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9eac1e6d4a18bcee948c136ec065a568",
     "wof:hierarchy":[
         {
@@ -391,7 +394,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603763,
+    "wof:lastmodified":1582332203,
     "wof:name":"Stepanakert",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/93/85668693.geojson
+++ b/data/856/686/93/85668693.geojson
@@ -242,6 +242,9 @@
         "wk:page":"Goranboy District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"becff7a8297d03a68ca92b511220c57e",
     "wof:hierarchy":[
         {
@@ -258,7 +261,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Naftalan",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/686/97/85668697.geojson
+++ b/data/856/686/97/85668697.geojson
@@ -257,6 +257,9 @@
         "qs_pg:id":245193
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d59c3d319d901d1d7da773abaf5a082a",
     "wof:hierarchy":[
         {
@@ -273,7 +276,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603764,
+    "wof:lastmodified":1582332203,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/687/01/85668701.geojson
+++ b/data/856/687/01/85668701.geojson
@@ -234,6 +234,9 @@
         "wk:page":"Sabirabad District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"289a83ff438a1d168d3268aa9b5416ad",
     "wof:hierarchy":[
         {
@@ -250,7 +253,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"Shirvan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/687/07/85668707.geojson
+++ b/data/856/687/07/85668707.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":32219
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"31c478374195ded93aa05f9c521c624e",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"\u015e\u0259ki",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/687/11/85668711.geojson
+++ b/data/856/687/11/85668711.geojson
@@ -238,6 +238,9 @@
         "wk:page":"Shusha"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22437d2ede2c34344431cf9637fe5e4a",
     "wof:hierarchy":[
         {
@@ -254,7 +257,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"\u015eu\u015fa",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/687/15/85668715.geojson
+++ b/data/856/687/15/85668715.geojson
@@ -291,6 +291,9 @@
         "wk:page":"Yevlakh District"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fe13a75c72f38ec3c7dc2dead5e71c3a",
     "wof:hierarchy":[
         {
@@ -307,7 +310,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"Yevlakh",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/687/17/85668717.geojson
+++ b/data/856/687/17/85668717.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":1237266
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d97f698fed01f9f48ec9278b1e28918a",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1566603765,
+    "wof:lastmodified":1582332203,
     "wof:name":"Kangarli",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/859/030/39/85903039.geojson
+++ b/data/859/030/39/85903039.geojson
@@ -150,6 +150,9 @@
         "wk:page":"Bak\u0131xanov"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91e9b70fe4981200804d5fdc367356ab",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Bak\u1e2fxanov",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/030/41/85903041.geojson
+++ b/data/859/030/41/85903041.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q4986854"
     },
     "wof:country":"AZ",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"463fad16708d6de8126c9bfd3821be10",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566603762,
+    "wof:lastmodified":1582332202,
     "wof:name":"Bukhta-Il'icha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/438/259/890438259.geojson
+++ b/data/890/438/259/890438259.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"AZ",
     "wof:created":1469052186,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68d52c52fc2eaa3007fba112042c1c1b",
     "wof:hierarchy":[
         {
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890438259,
-    "wof:lastmodified":1543954362,
+    "wof:lastmodified":1582332213,
     "wof:name":"Shahbuz",
     "wof:parent_id":85668683,
     "wof:placetype":"county",

--- a/data/890/438/263/890438263.geojson
+++ b/data/890/438/263/890438263.geojson
@@ -74,6 +74,9 @@
     },
     "wof:country":"AZ",
     "wof:created":1469052186,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"583c3cb4d7fe92432bb2f8f057eb4bb4",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890438263,
-    "wof:lastmodified":1543954362,
+    "wof:lastmodified":1582332214,
     "wof:name":"Julfa",
     "wof:parent_id":85668677,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.