### PR TITLE
az concordances, placetype local, and more

### DIFF
--- a/data/109/200/169/5/1092001695.geojson
+++ b/data/109/200/169/5/1092001695.geojson
@@ -72,6 +72,7 @@
     "wof:concordances":{
         "hasc:id":"AZ.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AZ",
     "wof:created":1473896593,
     "wof:geomhash":"281f0726ef81c4e642a2c4fd4b966408",
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1092001695,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886808,
     "wof:name":"Neftchala",
     "wof:parent_id":85668409,
     "wof:placetype":"county",

--- a/data/110/880/860/7/1108808607.geojson
+++ b/data/110/880/860/7/1108808607.geojson
@@ -60,7 +60,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884141,
     "wof:name":"Kalbajar-Lachin",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/860/9/1108808609.geojson
+++ b/data/110/880/860/9/1108808609.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493047,
+    "wof:lastmodified":1695884141,
     "wof:name":"Ganja-Gazakh",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/861/1/1108808611.geojson
+++ b/data/110/880/861/1/1108808611.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884141,
     "wof:name":"Daghlig Shirvan",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/861/5/1108808615.geojson
+++ b/data/110/880/861/5/1108808615.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884142,
     "wof:name":"Yukhari Garabakh",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/861/7/1108808617.geojson
+++ b/data/110/880/861/7/1108808617.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694498185,
+    "wof:lastmodified":1695884142,
     "wof:name":"Nax\u00e7\u0131van Autonomous Republic",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/861/9/1108808619.geojson
+++ b/data/110/880/861/9/1108808619.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884142,
     "wof:name":"Shaki-Zaqatala",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/862/1/1108808621.geojson
+++ b/data/110/880/862/1/1108808621.geojson
@@ -69,7 +69,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493047,
+    "wof:lastmodified":1695884141,
     "wof:name":"Absheron",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/862/3/1108808623.geojson
+++ b/data/110/880/862/3/1108808623.geojson
@@ -57,7 +57,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493048,
+    "wof:lastmodified":1695884141,
     "wof:name":"Guba-Khachmaz",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/862/5/1108808625.geojson
+++ b/data/110/880/862/5/1108808625.geojson
@@ -317,7 +317,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493060,
+    "wof:lastmodified":1695884163,
     "wof:name":"Lankaran",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/110/880/862/7/1108808627.geojson
+++ b/data/110/880/862/7/1108808627.geojson
@@ -111,7 +111,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694493047,
+    "wof:lastmodified":1695884141,
     "wof:name":"Aran",
     "wof:parent_id":85632717,
     "wof:placetype":"macroregion",

--- a/data/856/327/17/85632717.geojson
+++ b/data/856/327/17/85632717.geojson
@@ -1429,6 +1429,7 @@
         "hasc:id":"AZ",
         "icao:code":"4K",
         "ioc:id":"AZE",
+        "iso:code":"AZ",
         "itu:id":"AZE",
         "loc:id":"n92000010",
         "m49:code":"031",
@@ -1443,6 +1444,7 @@
         "wk:page":"Azerbaijan",
         "wmo:id":"AJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:country_alpha3":"AZE",
     "wof:geom_alt":[
@@ -1465,7 +1467,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1694639630,
+    "wof:lastmodified":1695881291,
     "wof:name":"Azerbaijan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/681/95/85668195.geojson
+++ b/data/856/681/95/85668195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166771,
-    "geom:area_square_m":1550290096.714323,
+    "geom:area_square_m":1550289465.682878,
     "geom:bbox":"45.093358,40.962857,45.790553,41.467184",
     "geom:latitude":41.254967,
     "geom:longitude":45.457717,
@@ -318,17 +318,19 @@
         "gn:id":828297,
         "gp:id":20070266,
         "hasc:id":"AZ.AF",
+        "iso:code":"AZ-AGA",
         "iso:id":"AZ-AGA",
         "qs_pg:id":894096,
         "unlc:id":"AZ-AGA",
         "wd:id":"Q275744",
         "wk:page":"Agstafa District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c2d48b091af76c90cd4aa2eb1b978a7d",
+    "wof:geomhash":"cdf9ac1242500664746a59641e47349b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -344,7 +346,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855725,
+    "wof:lastmodified":1695884357,
     "wof:name":"A\u011fstafa",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/681/99/85668199.geojson
+++ b/data/856/681/99/85668199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110034,
-    "geom:area_square_m":1035051117.166383,
+    "geom:area_square_m":1035051235.761587,
     "geom:bbox":"45.831525,40.296672,46.258511,40.681797",
     "geom:latitude":40.471054,
     "geom:longitude":46.034381,
@@ -246,15 +246,17 @@
         "gn:id":586771,
         "gp:id":20070222,
         "hasc:id":"AZ.DS",
+        "iso:code":"AZ-DAS",
         "iso:id":"AZ-DAS",
         "qs_pg:id":1006793,
         "wd:id":"Q2332472"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c089b9980960a7723184a35fbc7daee3",
+    "wof:geomhash":"4f9f4a93db6dabd988850f0ab8a7b032",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -270,7 +272,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855725,
+    "wof:lastmodified":1695884481,
     "wof:name":"Da\u015fk\u0259s\u0259n",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/05/85668205.geojson
+++ b/data/856/682/05/85668205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13143,
-    "geom:area_square_m":1234744685.941868,
+    "geom:area_square_m":1234744695.700745,
     "geom:bbox":"45.365732,40.31782,45.931092,40.788646",
     "geom:latitude":40.555816,
     "geom:longitude":45.678326,
@@ -251,15 +251,17 @@
         "gn:id":627535,
         "gp:id":20070230,
         "hasc:id":"AZ.GD",
+        "iso:code":"AZ-GAD",
         "iso:id":"AZ-GAD",
         "qs_pg:id":1172847,
         "wd:id":"Q2352160"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"361e1d5240da5e14e253a75cbb8f99b7",
+    "wof:geomhash":"e4147160a7b5e538a210d17216f0c544",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -275,7 +277,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855728,
+    "wof:lastmodified":1695884481,
     "wof:name":"G\u0259d\u0259b\u0259y",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/09/85668209.geojson
+++ b/data/856/682/09/85668209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007576,
-    "geom:area_square_m":71050194.379696,
+    "geom:area_square_m":71050231.906084,
     "geom:bbox":"46.309464,40.611124,46.449725,40.717724",
     "geom:latitude":40.673546,
     "geom:longitude":46.364821,
@@ -145,14 +145,16 @@
         "gn:id":828298,
         "gp:id":20070231,
         "hasc:id":"AZ.GA",
+        "iso:code":"AZ-GA",
         "iso:id":"AZ-GA",
         "qs_pg:id":420489
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6708dd88aa3643aef0a02c0e5d26473",
+    "wof:geomhash":"47e32c621908f3fbb1af383b9cb4d324",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +170,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521582,
+    "wof:lastmodified":1695884737,
     "wof:name":"G\u0259nc\u0259",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/11/85668211.geojson
+++ b/data/856/682/11/85668211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10366,
-    "geom:area_square_m":974162145.658965,
+    "geom:area_square_m":974162235.517194,
     "geom:bbox":"46.145179,40.290636,46.524467,40.787193",
     "geom:latitude":40.535034,
     "geom:longitude":46.324337,
@@ -291,16 +291,18 @@
         "gn:id":585967,
         "gp:id":20070268,
         "hasc:id":"AZ.XR",
+        "iso:code":"AZ-GYG",
         "iso:id":"AZ-GYG",
         "qs_pg:id":500537,
         "wd:id":"Q388087",
         "wk:page":"Goygol District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"912e9f45505f277e0f644d6a0fdf395c",
+    "wof:geomhash":"7e203f0920430d50e8c67299660b7208",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -316,7 +318,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855728,
+    "wof:lastmodified":1695884853,
     "wof:name":"Xanlar",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/15/85668215.geojson
+++ b/data/856/682/15/85668215.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.182093,
-    "geom:area_square_m":1710542080.314952,
+    "geom:area_square_m":1710542068.849535,
     "geom:bbox":"46.333116,40.270779,47.001833,40.9251",
     "geom:latitude":40.562553,
     "geom:longitude":46.648728,
@@ -258,16 +258,18 @@
         "gn:id":586112,
         "gp:id":20070261,
         "hasc:id":"AZ.GR",
+        "iso:code":"AZ-GOR",
         "iso:id":"AZ-GOR",
         "qs_pg:id":49485,
         "wd:id":"Q330843",
         "wk:page":"Goranboy District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea959f18325af75b15eb0c556c8aa288",
+    "wof:geomhash":"83f1869c3762761913b849fb5f4bf1b5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855730,
+    "wof:lastmodified":1695884854,
     "wof:name":"Goranboy",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/21/85668221.geojson
+++ b/data/856/682/21/85668221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.292068,
-    "geom:area_square_m":2763406113.93819,
+    "geom:area_square_m":2763405798.034872,
     "geom:bbox":"45.601652,39.791715,46.735946,40.31851",
     "geom:latitude":40.077454,
     "geom:longitude":46.192142,
@@ -150,14 +150,16 @@
         "gn:id":586047,
         "gp:id":20070273,
         "hasc:id":"AZ.KA",
+        "iso:code":"AZ-KAL",
         "iso:id":"AZ-KAL",
         "qs_pg:id":245251
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"15865a403f3ed6aafd504827ca81e271",
+    "wof:geomhash":"0dec5d44639cdea68634693897548767",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"K\u0259lb\u0259c\u0259r",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/682/25/85668225.geojson
+++ b/data/856/682/25/85668225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016486,
-    "geom:area_square_m":154342545.620556,
+    "geom:area_square_m":154342569.172492,
     "geom:bbox":"46.898919,40.729558,47.096863,40.861972",
     "geom:latitude":40.789536,
     "geom:longitude":46.996258,
@@ -142,14 +142,16 @@
         "gn:id":828299,
         "gp:id":20070240,
         "hasc:id":"AZ.MI",
+        "iso:code":"AZ-MI",
         "iso:id":"AZ-MI",
         "qs_pg:id":1015437
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"adeb739d8067130bd86370315e013e03",
+    "wof:geomhash":"1f2fa818382227d4ac3b2d04b55f75ed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"Ming\u0259\u00e7evir",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/29/85668229.geojson
+++ b/data/856/682/29/85668229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071001,
-    "geom:area_square_m":660982604.095414,
+    "geom:area_square_m":660982332.101494,
     "geom:bbox":"44.959678,40.976767,45.37757,41.349161",
     "geom:latitude":41.159919,
     "geom:longitude":45.205472,
@@ -327,17 +327,19 @@
         "gn:id":586087,
         "gp:id":20070267,
         "hasc:id":"AZ.QZ",
+        "iso:code":"AZ-QAZ",
         "iso:id":"AZ-QAZ",
         "qs_pg:id":500536,
         "unlc:id":"AZ-QAZ",
         "wd:id":"Q389381",
         "wk:page":"Qazakh District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dc75132ecc02f38b890186aebd0ff282",
+    "wof:geomhash":"d7c8dd8f2b8499b8137499ae211f3ef4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -353,7 +355,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855729,
+    "wof:lastmodified":1695884854,
     "wof:name":"Qazax",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/33/85668233.geojson
+++ b/data/856/682/33/85668233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176573,
-    "geom:area_square_m":1651532405.427994,
+    "geom:area_square_m":1651532408.925279,
     "geom:bbox":"45.724811,40.623795,46.360617,41.125016",
     "geom:latitude":40.850354,
     "geom:longitude":46.060854,
@@ -314,15 +314,17 @@
         "gn:id":585059,
         "gp:id":20070244,
         "hasc:id":"AZ.SM",
+        "iso:code":"AZ-SKR",
         "iso:id":"AZ-SKR",
         "qs_pg:id":1092314,
         "wd:id":"Q390783"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8ffc374ecbf2df54e90c1bb01c1a41cc",
+    "wof:geomhash":"d688536cd6cbcb76a7ebc194a887b5ba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855728,
+    "wof:lastmodified":1695884481,
     "wof:name":"\u015e\u0259mkir",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/35/85668235.geojson
+++ b/data/856/682/35/85668235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158228,
-    "geom:area_square_m":1477589550.67646,
+    "geom:area_square_m":1477589366.645168,
     "geom:bbox":"46.10291,40.691044,46.823762,41.205996",
     "geom:latitude":40.955886,
     "geom:longitude":46.484182,
@@ -299,17 +299,19 @@
         "gn:id":828302,
         "gp:id":20070269,
         "hasc:id":"AZ.SX",
+        "iso:code":"AZ-SMX",
         "iso:id":"AZ-SMX",
         "qs_pg:id":49486,
         "unlc:id":"AZ-SMX",
         "wd:id":"Q498437",
         "wk:page":"Samukh District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c69d2bc0606e461471f4edd9479eaf7",
+    "wof:geomhash":"edb88a063d1042c9055908b9a2e8fb90",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855727,
+    "wof:lastmodified":1695884853,
     "wof:name":"Samux",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/41/85668241.geojson
+++ b/data/856/682/41/85668241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199341,
-    "geom:area_square_m":1860687615.439357,
+    "geom:area_square_m":1860687260.666048,
     "geom:bbox":"45.445818,40.611792,46.208016,41.235143",
     "geom:latitude":40.985317,
     "geom:longitude":45.777146,
@@ -311,17 +311,19 @@
         "gn:id":584861,
         "gp:id":20070248,
         "hasc:id":"AZ.TO",
+        "iso:code":"AZ-TOV",
         "iso:id":"AZ-TOV",
         "qs_pg:id":989056,
         "unlc:id":"AZ-TOV",
         "wd:id":"Q388980",
         "wk:page":"Tovuz District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c95aede323332a23f3a29348cfa7e158",
+    "wof:geomhash":"2e3186a4d838644a71a76e9ff520b48b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855730,
+    "wof:lastmodified":1695884854,
     "wof:name":"Tovuz",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/682/43/85668243.geojson
+++ b/data/856/682/43/85668243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155241,
-    "geom:area_square_m":1454691521.332292,
+    "geom:area_square_m":1454691112.898733,
     "geom:bbox":"46.710455,40.446916,47.328983,40.981861",
     "geom:latitude":40.727834,
     "geom:longitude":47.01209,
@@ -324,16 +324,18 @@
         "gn:id":584650,
         "gp:id":20070252,
         "hasc:id":"AZ.YV",
+        "iso:code":"AZ-YEV",
         "iso:id":"AZ-YEV",
         "qs_pg:id":49483,
         "wd:id":"Q458524",
         "wk:page":"Yevlakh District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"41a9b09540425fbd39b29f31946a93b0",
+    "wof:geomhash":"04b6ea9f4804271062e47e9d816ef883",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855729,
+    "wof:lastmodified":1695884854,
     "wof:name":"Yevlakh Rayon",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/49/85668249.geojson
+++ b/data/856/682/49/85668249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231941,
-    "geom:area_square_m":2187082046.979884,
+    "geom:area_square_m":2187083204.976621,
     "geom:bbox":"49.296212,39.613666,50.619649,40.598272",
     "geom:latitude":40.307073,
     "geom:longitude":49.773181,
@@ -776,17 +776,19 @@
         "gn:id":587081,
         "gp:id":20070218,
         "hasc:id":"AZ.BA",
+        "iso:code":"AZ-BA",
         "iso:id":"AZ-BA",
         "qs_pg:id":219914,
         "unlc:id":"AZ-BA",
         "wd:id":"Q9248",
         "wk:page":"Baku"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"179483fec530259ad9f55b0dfaa1619f",
+    "wof:geomhash":"48653c1c73de5c80baea7d691c8fbf7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -802,7 +804,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855731,
+    "wof:lastmodified":1695884357,
     "wof:name":"Bak\u0131",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/682/51/85668251.geojson
+++ b/data/856/682/51/85668251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207161,
-    "geom:area_square_m":1952165975.431476,
+    "geom:area_square_m":1952166095.187238,
     "geom:bbox":"48.877158,39.990872,49.933734,40.686626",
     "geom:latitude":40.350883,
     "geom:longitude":49.348949,
@@ -332,17 +332,19 @@
         "gn:id":587245,
         "gp:id":20070283,
         "hasc:id":"AZ.AR",
+        "iso:code":"AZ-ABS",
         "iso:id":"AZ-ABS",
         "qs_pg:id":348996,
         "unlc:id":"AZ-ABS",
         "wd:id":"Q179538",
         "wk:page":"Absheron District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"562a4ec4e597606ab60b1fb7964c1ed9",
+    "wof:geomhash":"5bc443ca373375627e5acd81f865271c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -358,7 +360,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855727,
+    "wof:lastmodified":1695884357,
     "wof:name":"Ab\u015feron",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/682/57/85668257.geojson
+++ b/data/856/682/57/85668257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115799,
-    "geom:area_square_m":1096149600.878602,
+    "geom:area_square_m":1096149409.297554,
     "geom:bbox":"46.641851,39.827966,47.284454,40.24184",
     "geom:latitude":40.045379,
     "geom:longitude":46.981462,
@@ -340,17 +340,19 @@
         "gn:id":148617,
         "gp:id":20070258,
         "hasc:id":"AZ.AM",
+        "iso:code":"AZ-AGM",
         "iso:id":"AZ-AGM",
         "qs_pg:id":1189260,
         "unlc:id":"AZ-AGM",
         "wd:id":"Q201647",
         "wk:page":"Agdam District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9be8b8806e6518563d2b5953f23f03a7",
+    "wof:geomhash":"f56b4ad0b1b60a671a11ea3421351f31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855727,
+    "wof:lastmodified":1695884357,
     "wof:name":"A\u011fdam",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/682/59/85668259.geojson
+++ b/data/856/682/59/85668259.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115049,
-    "geom:area_square_m":1080213151.465434,
+    "geom:area_square_m":1080213195.208692,
     "geom:bbox":"47.209214,40.319813,47.633369,40.7985",
     "geom:latitude":40.595337,
     "geom:longitude":47.413785,
@@ -315,17 +315,19 @@
         "gn:id":587376,
         "gp:id":20070213,
         "hasc:id":"AZ.AS",
+        "iso:code":"AZ-AGS",
         "iso:id":"AZ-AGS",
         "qs_pg:id":202010,
         "unlc:id":"AZ-AGS",
         "wd:id":"Q275784",
         "wk:page":"Agdash District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"272349f3c1a2b78c32926bf98dc483da",
+    "wof:geomhash":"1ef99badade5a792d976782715721be1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -341,7 +343,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855727,
+    "wof:lastmodified":1695884357,
     "wof:name":"A\u011fda\u015f",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/89/85668289.geojson
+++ b/data/856/682/89/85668289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108806,
-    "geom:area_square_m":1022521516.202592,
+    "geom:area_square_m":1022521082.577167,
     "geom:bbox":"48.084655,40.314278,48.651163,40.816142",
     "geom:latitude":40.53513,
     "geom:longitude":48.397365,
@@ -317,17 +317,19 @@
         "gn:id":587342,
         "gp:id":20070215,
         "hasc:id":"AZ.AU",
+        "iso:code":"AZ-AGU",
         "iso:id":"AZ-AGU",
         "qs_pg:id":202009,
         "unlc:id":"AZ-AGU",
         "wd:id":"Q330800",
         "wk:page":"Agsu District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0739e33bcafac12363430092598acc75",
+    "wof:geomhash":"6ddc5ea688e3847de9e49675dc86f517",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855729,
+    "wof:lastmodified":1695884357,
     "wof:name":"A\u011fsu",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/682/93/85668293.geojson
+++ b/data/856/682/93/85668293.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193311,
-    "geom:area_square_m":1828156817.03431,
+    "geom:area_square_m":1828157135.085705,
     "geom:bbox":"48.473566,39.830329,49.359946,40.36137",
     "geom:latitude":40.109326,
     "geom:longitude":48.919929,
@@ -149,15 +149,17 @@
         "gn:id":828315,
         "gp:id":20070282,
         "hasc:id":"AZ.HA",
+        "iso:code":"AZ-HAC",
         "iso:id":"AZ-HAC",
         "qs_pg:id":245892,
         "unlc:id":"AZ-HAC"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f4362fe1273a78618ab401922a14b9f8",
+    "wof:geomhash":"6e94cc0d1903a2c64a240b779c3bc410",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497568,
+    "wof:lastmodified":1695884853,
     "wof:name":"Hajigabul",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/682/97/85668297.geojson
+++ b/data/856/682/97/85668297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065522,
-    "geom:area_square_m":633933537.865353,
+    "geom:area_square_m":633934000.181554,
     "geom:bbox":"48.483703,38.391823,48.868862,38.625029",
     "geom:latitude":38.514925,
     "geom:longitude":48.694756,
@@ -326,17 +326,19 @@
         "gn:id":148442,
         "gp:id":20070217,
         "hasc:id":"AZ.AA",
+        "iso:code":"AZ-AST",
         "iso:id":"AZ-AST",
         "qs_pg:id":1329936,
         "unlc:id":"AZ-AST",
         "wd:id":"Q269680",
         "wk:page":"Astara District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55c2afa245835a7f8fe36a19eba7ca25",
+    "wof:geomhash":"2e487f2800ba2bb8581cb5a9f50104cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -352,7 +354,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855729,
+    "wof:lastmodified":1695884854,
     "wof:name":"Astara",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/03/85668303.geojson
+++ b/data/856/683/03/85668303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100361,
-    "geom:area_square_m":945896148.697931,
+    "geom:area_square_m":945895882.784276,
     "geom:bbox":"47.014552,40.169557,47.491996,40.548958",
     "geom:latitude":40.340284,
     "geom:longitude":47.221865,
@@ -145,14 +145,16 @@
         "gn:id":587056,
         "gp:id":20070219,
         "hasc:id":"AZ.BR",
+        "iso:code":"AZ-BAR",
         "iso:id":"AZ-BAR",
         "qs_pg:id":66061
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a44502f7d35bce3503a2b35187ff1a51",
+    "wof:geomhash":"fa54becc8d730b28a96af194b320ec15",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -168,7 +170,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521582,
+    "wof:lastmodified":1695884737,
     "wof:name":"B\u0259rd\u0259",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/13/85668313.geojson
+++ b/data/856/683/13/85668313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1152,
-    "geom:area_square_m":1094150440.783592,
+    "geom:area_square_m":1094150216.173356,
     "geom:bbox":"47.441022,39.570044,47.927076,40.137168",
     "geom:latitude":39.815496,
     "geom:longitude":47.683889,
@@ -142,14 +142,16 @@
         "gn:id":146879,
         "gp:id":20070257,
         "hasc:id":"AZ.BQ",
+        "iso:code":"AZ-BEY",
         "iso:id":"AZ-BEY",
         "qs_pg:id":128258
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a0acfdeb075d0e27b9ba6ace4bc75697",
+    "wof:geomhash":"9cdb9dabd25d6487c5f18cbb7434a1b2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521582,
+    "wof:lastmodified":1695884737,
     "wof:name":"Beyl\u0259qan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/17/85668317.geojson
+++ b/data/856/683/17/85668317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140194,
-    "geom:area_square_m":1337059427.467663,
+    "geom:area_square_m":1337060377.541959,
     "geom:bbox":"47.988892,39.328343,48.768792,39.729523",
     "geom:latitude":39.529687,
     "geom:longitude":48.465031,
@@ -217,14 +217,16 @@
         "gn:id":147310,
         "gp:id":20070242,
         "hasc:id":"AZ.BS",
+        "iso:code":"AZ-BIL",
         "iso:id":"AZ-BIL",
         "qs_pg:id":1092313
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63ec4de3b0a5bafc1875cb1980dcb04f",
+    "wof:geomhash":"f6915233efa5b24f72411c708cbe5dac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -240,7 +242,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521582,
+    "wof:lastmodified":1695884737,
     "wof:name":"Bil\u0259suvar",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/23/85668323.geojson
+++ b/data/856/683/23/85668323.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104291,
-    "geom:area_square_m":997462938.590378,
+    "geom:area_square_m":997462914.70392,
     "geom:bbox":"46.705361,39.132891,47.312456,39.500036",
     "geom:latitude":39.332813,
     "geom:longitude":46.976789,
@@ -150,14 +150,16 @@
         "gn:id":148140,
         "gp:id":20070224,
         "hasc:id":"AZ.CB",
+        "iso:code":"AZ-CAB",
         "iso:id":"AZ-CAB",
         "qs_pg:id":1172844
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e0c9428d5851a5e07d3ffdbdd151c4ab",
+    "wof:geomhash":"4f1591d1f198103cfa716a9599325001",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -173,7 +175,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"C\u0259bray\u0131l",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/683/31/85668331.geojson
+++ b/data/856/683/31/85668331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147671,
-    "geom:area_square_m":1414436844.138234,
+    "geom:area_square_m":1414436825.175012,
     "geom:bbox":"48.134964,39.019571,48.72817,39.446025",
     "geom:latitude":39.229587,
     "geom:longitude":48.452211,
@@ -301,15 +301,17 @@
         "gn:id":148155,
         "gp:id":20070223,
         "hasc:id":"AZ.CL",
+        "iso:code":"AZ-CAL",
         "iso:id":"AZ-CAL",
         "qs_pg:id":1172843,
         "wd:id":"Q1020627"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32e5b3910e853238590e15920b26a751",
+    "wof:geomhash":"da5621d944894bf0021e71d748aaff37",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855736,
+    "wof:lastmodified":1695884481,
     "wof:name":"C\u0259lilabad",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/39/85668339.geojson
+++ b/data/856/683/39/85668339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116659,
-    "geom:area_square_m":1085665332.971075,
+    "geom:area_square_m":1085665480.68159,
     "geom:bbox":"48.698321,40.903916,49.17347,41.387735",
     "geom:latitude":41.182041,
     "geom:longitude":48.913742,
@@ -173,14 +173,16 @@
         "gn:id":586725,
         "gp:id":20070279,
         "hasc:id":"AZ.DV",
+        "iso:code":"AZ-SBN",
         "iso:id":"AZ-SBN",
         "qs_pg:id":245519
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e7b1801b14fb84c1101a3bfcac7ef0a6",
+    "wof:geomhash":"9891d0336086dd732f4ba56b1468ea73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -196,7 +198,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1614892864,
+    "wof:lastmodified":1695884481,
     "wof:name":"D\u0259v\u0259\u00e7i",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/683/51/85668351.geojson
+++ b/data/856/683/51/85668351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.140905,
-    "geom:area_square_m":1342769667.196221,
+    "geom:area_square_m":1342769899.329226,
     "geom:bbox":"47.03014,39.389377,47.664217,39.772007",
     "geom:latitude":39.58507,
     "geom:longitude":47.341142,
@@ -325,17 +325,19 @@
         "gn:id":148107,
         "gp:id":20070225,
         "hasc:id":"AZ.FU",
+        "iso:code":"AZ-FUZ",
         "iso:id":"AZ-FUZ",
         "qs_pg:id":202011,
         "unlc:id":"AZ-FUZ",
         "wd:id":"Q331687",
         "wk:page":"Fuzuli District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a676fba6f4035a965c91f2e41c8277bf",
+    "wof:geomhash":"15c21ba62a1342b4505e642ed4e1f3f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855735,
+    "wof:lastmodified":1695884358,
     "wof:name":"F\u00fczuli",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/683/57/85668357.geojson
+++ b/data/856/683/57/85668357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072806,
-    "geom:area_square_m":683768732.176829,
+    "geom:area_square_m":683768885.595378,
     "geom:bbox":"47.607247,40.458199,48.086118,40.689957",
     "geom:latitude":40.578155,
     "geom:longitude":47.856951,
@@ -309,17 +309,19 @@
         "gn:id":586482,
         "gp:id":20070226,
         "hasc:id":"AZ.GY",
+        "iso:code":"AZ-GOY",
         "iso:id":"AZ-GOY",
         "qs_pg:id":500535,
         "unlc:id":"AZ-GOY",
         "wd:id":"Q477163",
         "wk:page":"Goychay District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd733a762d4a0a1d9fd84e5eb07ddf7e",
+    "wof:geomhash":"3033ffdc066b1b2af72afc9f543d6c54",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -335,7 +337,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855735,
+    "wof:lastmodified":1695884358,
     "wof:name":"G\u00f6y\u00e7ay",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/65/85668365.geojson
+++ b/data/856/683/65/85668365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.201451,
-    "geom:area_square_m":1911713404.710054,
+    "geom:area_square_m":1911713452.335778,
     "geom:bbox":"47.750876,39.58906,48.39511,40.1537",
     "geom:latitude":39.874097,
     "geom:longitude":48.054263,
@@ -305,17 +305,19 @@
         "gn:id":147983,
         "gp:id":20070227,
         "hasc:id":"AZ.IM",
+        "iso:code":"AZ-IMI",
         "iso:id":"AZ-IMI",
         "qs_pg:id":49469,
         "unlc:id":"AZ-IMI",
         "wd:id":"Q343908",
         "wk:page":"Imishli District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1b4a440a9e7c745dc9d43d50707966b5",
+    "wof:geomhash":"7efd66c49be91e1746878243bf713463",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855736,
+    "wof:lastmodified":1695884358,
     "wof:name":"\u0130mi\u015fli",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/73/85668373.geojson
+++ b/data/856/683/73/85668373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226446,
-    "geom:area_square_m":2119113621.140129,
+    "geom:area_square_m":2119113769.879751,
     "geom:bbox":"47.77389,40.52877,48.561392,41.099088",
     "geom:latitude":40.815704,
     "geom:longitude":48.188593,
@@ -252,16 +252,18 @@
         "gn:id":586320,
         "gp:id":20070228,
         "hasc:id":"AZ.IS",
+        "iso:code":"AZ-ISM",
         "iso:id":"AZ-ISM",
         "qs_pg:id":211805,
         "unlc:id":"AZ-ISM",
         "wd:id":"Q2148072"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28fc90885a0c98b1c96c07e61d0009dd",
+    "wof:geomhash":"2903d18f9270fd273bd60fb56e96cfc5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855735,
+    "wof:lastmodified":1695884481,
     "wof:name":"\u0130smay\u0131ll\u0131",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/683/83/85668383.geojson
+++ b/data/856/683/83/85668383.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178779,
-    "geom:area_square_m":1686813935.825351,
+    "geom:area_square_m":1686814136.676333,
     "geom:bbox":"47.909573,40.039963,48.50029,40.530689",
     "geom:latitude":40.266376,
     "geom:longitude":48.208427,
@@ -247,15 +247,17 @@
         "gn:id":585686,
         "gp:id":20070236,
         "hasc:id":"AZ.KU",
+        "iso:code":"AZ-KUR",
         "iso:id":"AZ-KUR",
         "qs_pg:id":972407,
         "wd:id":"Q1851063"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a95d970867da4aaf71119205cb869a2a",
+    "wof:geomhash":"9e639f63b9d3cf7a380bde6da6beddb5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -271,7 +273,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855736,
+    "wof:lastmodified":1695884481,
     "wof:name":"K\u00fcrd\u0259mir",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/683/89/85668389.geojson
+++ b/data/856/683/89/85668389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122359,
-    "geom:area_square_m":1176947836.67676,
+    "geom:area_square_m":1176947438.561919,
     "geom:bbox":"48.516196,38.599124,49.211395,39.296086",
     "geom:latitude":38.931488,
     "geom:longitude":48.844669,
@@ -268,14 +268,16 @@
         "fips:code":"AJ29",
         "gp:id":20070263,
         "hasc:id":"AZ.LN",
+        "iso:code":"AZ-LAN",
         "iso:id":"AZ-LAN",
         "qs_pg:id":245193
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0cde4f2c77bff904627c5bcb89f3c3ae",
+    "wof:geomhash":"9dd49595fd657eaf38cd09c652c6ce39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497571,
+    "wof:lastmodified":1695884854,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/683/97/85668397.geojson
+++ b/data/856/683/97/85668397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081321,
-    "geom:area_square_m":781308819.8924,
+    "geom:area_square_m":781308761.824118,
     "geom:bbox":"48.446385,38.856272,48.86985,39.203788",
     "geom:latitude":39.013289,
     "geom:longitude":48.682449,
@@ -260,16 +260,18 @@
         "gn:id":147551,
         "gp:id":20070239,
         "hasc:id":"AZ.MA",
+        "iso:code":"AZ-MAS",
         "iso:id":"AZ-MAS",
         "qs_pg:id":1092312,
         "unlc:id":"AZ-MAS",
         "wd:id":"Q512116"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5e63902931fa6d9e5b8c2a9486e71b61",
+    "wof:geomhash":"f19ef51f60c857c28de5a644840b2274",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855736,
+    "wof:lastmodified":1695884481,
     "wof:name":"Masall\u0131",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/684/03/85668403.geojson
+++ b/data/856/684/03/85668403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104119,
-    "geom:area_square_m":1004227330.317941,
+    "geom:area_square_m":1004227882.105737,
     "geom:bbox":"48.226342,38.542135,48.670022,38.958966",
     "geom:latitude":38.738286,
     "geom:longitude":48.444023,
@@ -308,17 +308,19 @@
         "gn:id":147610,
         "gp:id":20070238,
         "hasc:id":"AZ.LE",
+        "iso:code":"AZ-LER",
         "iso:id":"AZ-LER",
         "qs_pg:id":952215,
         "unlc:id":"AZ-LER",
         "wd:id":"Q688626",
         "wk:page":"Lerik District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53b10b25e404c57e0b498dea8654b6ca",
+    "wof:geomhash":"a2919d8cddc30d4d2cc0f7e56715dbf0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855733,
+    "wof:lastmodified":1695884854,
     "wof:name":"Lerik",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/684/09/85668409.geojson
+++ b/data/856/684/09/85668409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164623,
-    "geom:area_square_m":1574246025.746427,
+    "geom:area_square_m":1574245544.954076,
     "geom:bbox":"48.695491,38.957116,49.449513,39.60662",
     "geom:latitude":39.343413,
     "geom:longitude":49.047594,
@@ -306,17 +306,19 @@
         "gn:id":147422,
         "gp:id":20070241,
         "hasc:id":"AZ.NE",
+        "iso:code":"AZ-NEF",
         "iso:id":"AZ-NEF",
         "qs_pg:id":49481,
         "unlc:id":"AZ-NEF",
         "wd:id":"Q688633",
         "wk:page":"Neftchala District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17e26a76a6ea353c0250a7daf0686117",
+    "wof:geomhash":"04de376719adee639a88c3a158bbf72b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855734,
+    "wof:lastmodified":1695884358,
     "wof:name":"Neft\u00e7ala",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/19/85668419.geojson
+++ b/data/856/684/19/85668419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151989,
-    "geom:area_square_m":1428384110.831476,
+    "geom:area_square_m":1428383940.666377,
     "geom:bbox":"48.706056,40.309305,49.308841,40.780275",
     "geom:latitude":40.53288,
     "geom:longitude":48.965925,
@@ -305,17 +305,19 @@
         "gn:id":828301,
         "gp:id":20070272,
         "hasc:id":"AZ.QO",
+        "iso:code":"AZ-QOB",
         "iso:id":"AZ-QOB",
         "qs_pg:id":985379,
         "unlc:id":"AZ-QOB",
         "wd:id":"Q457508",
         "wk:page":"Gobustan District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c50702a6be7691b76107053f0bd80f5a",
+    "wof:geomhash":"924c9f60df92feac68e42b887696cd7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855733,
+    "wof:lastmodified":1695884854,
     "wof:name":"Qobustan",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/684/25/85668425.geojson
+++ b/data/856/684/25/85668425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.079624,
-    "geom:area_square_m":742747180.965374,
+    "geom:area_square_m":742747197.854389,
     "geom:bbox":"48.874628,40.874344,49.368074,41.21774",
     "geom:latitude":41.027784,
     "geom:longitude":49.101246,
@@ -220,14 +220,16 @@
         "gn:id":828304,
         "gp:id":20070278,
         "hasc:id":"AZ.SY",
+        "iso:code":"AZ-SIY",
         "iso:id":"AZ-SIY",
         "qs_pg:id":270754
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b6a7dab25639c5d003210654a749f56",
+    "wof:geomhash":"68e2d0028bdca301e69189da01fcc712",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -243,7 +245,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1614892864,
+    "wof:lastmodified":1695884481,
     "wof:name":"Siy\u0259z\u0259n",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/684/33/85668433.geojson
+++ b/data/856/684/33/85668433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119699,
-    "geom:area_square_m":1136489287.521554,
+    "geom:area_square_m":1136489246.650269,
     "geom:bbox":"48.22353,39.654479,48.709906,40.035021",
     "geom:latitude":39.838863,
     "geom:longitude":48.461136,
@@ -156,15 +156,17 @@
         "gn:id":147287,
         "gp:id":20070243,
         "hasc:id":"AZ.ST",
+        "iso:code":"AZ-SAT",
         "iso:id":"AZ-SAT",
         "qs_pg:id":211811,
         "unlc:id":"AZ-SAT"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ddd741a95c792773b78c77d33f3e228c",
+    "wof:geomhash":"06194381243aff6d2766bf1349eaa344",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884737,
     "wof:name":"Saatl\u0131",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/47/85668447.geojson
+++ b/data/856/684/47/85668447.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.163454,
-    "geom:area_square_m":1550469920.214355,
+    "geom:area_square_m":1550470206.222352,
     "geom:bbox":"48.244507,39.606106,48.975512,40.175545",
     "geom:latitude":39.903407,
     "geom:longitude":48.683122,
@@ -249,16 +249,18 @@
         "gn:id":147284,
         "gp:id":20070281,
         "hasc:id":"AZ.SB",
+        "iso:code":"AZ-SAB",
         "iso:id":"AZ-SAB",
         "qs_pg:id":49487,
         "wd:id":"Q382132",
         "wk:page":"Sabirabad District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"58b3551126aac485732c36c3b53b8aae",
+    "wof:geomhash":"7ed066651835a806b2d3d9aa02d97df3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855734,
+    "wof:lastmodified":1695884854,
     "wof:name":"Sabirabad",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/49/85668449.geojson
+++ b/data/856/684/49/85668449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192133,
-    "geom:area_square_m":1828746175.711998,
+    "geom:area_square_m":1828746594.103954,
     "geom:bbox":"48.730686,39.364419,49.358312,39.936048",
     "geom:latitude":39.668151,
     "geom:longitude":49.066574,
@@ -317,6 +317,7 @@
         "gn:id":147269,
         "gp:id":20070280,
         "hasc:id":"AZ.SL",
+        "iso:code":"AZ-SAL",
         "iso:id":"AZ-SAL",
         "loc:id":"n2014012125",
         "qs_pg:id":1149775,
@@ -324,11 +325,12 @@
         "wd:id":"Q457485",
         "wk:page":"Salyan District, Azerbaijan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbccc9b2e6d6e679d52e3ecf9cddb7e2",
+    "wof:geomhash":"0407a73f0007b184214ec7fd354e9820",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -344,7 +346,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855734,
+    "wof:lastmodified":1695884854,
     "wof:name":"Salyan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/59/85668459.geojson
+++ b/data/856/684/59/85668459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160045,
-    "geom:area_square_m":1502074960.370348,
+    "geom:area_square_m":1502074737.762875,
     "geom:bbox":"48.449835,40.242841,48.886165,40.971141",
     "geom:latitude":40.622502,
     "geom:longitude":48.662325,
@@ -143,15 +143,17 @@
         "gn:id":585030,
         "gp:id":20070270,
         "hasc:id":"AZ.SI",
+        "iso:code":"AZ-SMI",
         "iso:id":"AZ-SMI",
         "qs_pg:id":245209,
         "unlc:id":"AZ-SMI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01ca4b1f51b0d8371b0b82e97332c72f",
+    "wof:geomhash":"c84fc9b3283484fced9612c6c35d019a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884738,
     "wof:name":"\u015eamax\u0131",
     "wof:parent_id":1108808611,
     "wof:placetype":"region",

--- a/data/856/684/65/85668465.geojson
+++ b/data/856/684/65/85668465.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010257,
-    "geom:area_square_m":96282646.491705,
+    "geom:area_square_m":96282466.614396,
     "geom:bbox":"49.487927,40.537077,49.74227,40.742762",
     "geom:latitude":40.610876,
     "geom:longitude":49.628761,
@@ -413,17 +413,19 @@
         "gn:id":828305,
         "gp:id":20070247,
         "hasc:id":"AZ.SQ",
+        "iso:code":"AZ-SM",
         "iso:id":"AZ-SM",
         "qs_pg:id":1189262,
         "unlc:id":"AZ-SM",
         "wd:id":"Q179833",
         "wk:page":"Sumqayit"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ad0914c8b055eb7634829753531a84d",
+    "wof:geomhash":"0c761e1972ffd5b84a15425d3a21696d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -439,7 +441,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855734,
+    "wof:lastmodified":1695884358,
     "wof:name":"Sumqay\u0131t",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/684/75/85668475.geojson
+++ b/data/856/684/75/85668475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094287,
-    "geom:area_square_m":887454505.003371,
+    "geom:area_square_m":887454629.981651,
     "geom:bbox":"47.43377,40.292777,48.019093,40.571303",
     "geom:latitude":40.430498,
     "geom:longitude":47.729266,
@@ -305,17 +305,19 @@
         "gn:id":584783,
         "gp:id":20070249,
         "hasc:id":"AZ.UC",
+        "iso:code":"AZ-UCA",
         "iso:id":"AZ-UCA",
         "qs_pg:id":49482,
         "unlc:id":"AZ-UCA",
         "wd:id":"Q476703",
         "wk:page":"Ujar District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cde161d44cbdb476a4ba1adf2ce1ef17",
+    "wof:geomhash":"cecd34240e29232d428762592f95e28a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855733,
+    "wof:lastmodified":1695884854,
     "wof:name":"Ucar",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/684/85/85668485.geojson
+++ b/data/856/684/85/85668485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192584,
-    "geom:area_square_m":1803845591.775339,
+    "geom:area_square_m":1803845588.800286,
     "geom:bbox":"48.800114,40.518029,49.569391,41.000461",
     "geom:latitude":40.756359,
     "geom:longitude":49.20992,
@@ -143,15 +143,17 @@
         "gn:id":828306,
         "gp:id":20070271,
         "hasc:id":"AZ.XI",
+        "iso:code":"AZ-XIZ",
         "iso:id":"AZ-XIZ",
         "qs_pg:id":1013205,
         "unlc:id":"AZ-XIZ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fc345715603cfd0e14da7c22a5780302",
+    "wof:geomhash":"6f1b630217bc32fe61c7b123efee492f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -167,7 +169,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884738,
     "wof:name":"Xiz\u0131",
     "wof:parent_id":1108808621,
     "wof:placetype":"region",

--- a/data/856/684/97/85668497.geojson
+++ b/data/856/684/97/85668497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.071146,
-    "geom:area_square_m":684677286.649605,
+    "geom:area_square_m":684677553.111968,
     "geom:bbox":"48.007027,38.7286,48.535041,39.079239",
     "geom:latitude":38.896756,
     "geom:longitude":48.243097,
@@ -206,15 +206,17 @@
         "gn:id":146962,
         "gp:id":20070251,
         "hasc:id":"AZ.YR",
+        "iso:code":"AZ-YAR",
         "iso:id":"AZ-YAR",
         "qs_pg:id":1172849,
         "unlc:id":"AZ-YAR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29147e4802ead0af3c91f5330980179a",
+    "wof:geomhash":"2114f494494d13c1bfefb831bb8b5b35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -230,7 +232,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695884738,
     "wof:name":"Yard\u0131ml\u0131",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/685/09/85668509.geojson
+++ b/data/856/685/09/85668509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091971,
-    "geom:area_square_m":868022498.451412,
+    "geom:area_square_m":868022225.219039,
     "geom:bbox":"47.429523,40.066106,47.985589,40.402865",
     "geom:latitude":40.246693,
     "geom:longitude":47.718747,
@@ -142,14 +142,16 @@
         "gn:id":584583,
         "gp:id":20070256,
         "hasc:id":"AZ.ZR",
+        "iso:code":"AZ-ZAR",
         "iso:id":"AZ-ZAR",
         "qs_pg:id":128264
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a8292af0fde47d727d001998bc04e55f",
+    "wof:geomhash":"5af9bfe3365c0fd24f40db707c547f10",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521585,
+    "wof:lastmodified":1695884738,
     "wof:name":"Z\u0259rdab",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/685/19/85668519.geojson
+++ b/data/856/685/19/85668519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18423,
-    "geom:area_square_m":1744433384.396855,
+    "geom:area_square_m":1744433425.10588,
     "geom:bbox":"47.07391,39.73534,47.778713,40.256256",
     "geom:latitude":40.025016,
     "geom:longitude":47.417529,
@@ -282,15 +282,17 @@
         "gn:id":148615,
         "gp:id":20070214,
         "hasc:id":"AZ.AC",
+        "iso:code":"AZ-AGC",
         "iso:id":"AZ-AGC",
         "qs_pg:id":332219,
         "wd:id":"Q1983875"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05eb9f7bb1f7247b54678f1fd108dc5d",
+    "wof:geomhash":"8c0ade9ff69beaff6a6e7683ca5604be",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855731,
+    "wof:lastmodified":1695884481,
     "wof:name":"A\u011fcab\u0259di",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/685/31/85668531.geojson
+++ b/data/856/685/31/85668531.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095954,
-    "geom:area_square_m":885514570.849837,
+    "geom:area_square_m":885514421.32073,
     "geom:bbox":"46.197923,41.555236,46.744224,41.90861",
     "geom:latitude":41.726072,
     "geom:longitude":46.436387,
@@ -270,15 +270,17 @@
         "gn:id":587010,
         "gp:id":20070220,
         "hasc:id":"AZ.BL",
+        "iso:code":"AZ-BAL",
         "iso:id":"AZ-BAL",
         "qs_pg:id":212788,
         "wd:id":"Q1989793"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68b97ca6d59ba086fa0ad36bcff05d13",
+    "wof:geomhash":"ece0e891a369c34e356c21d6cef2ad00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855731,
+    "wof:lastmodified":1695884481,
     "wof:name":"Balak\u0259n",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/41/85668541.geojson
+++ b/data/856/685/41/85668541.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169057,
-    "geom:area_square_m":1579067897.463392,
+    "geom:area_square_m":1579068022.427813,
     "geom:bbox":"47.549178,40.65518,48.09405,41.221311",
     "geom:latitude":40.941059,
     "geom:longitude":47.808271,
@@ -142,14 +142,16 @@
         "gn:id":585738,
         "gp:id":20070235,
         "hasc:id":"AZ.QA",
+        "iso:code":"AZ-QAB",
         "iso:id":"AZ-QAB",
         "qs_pg:id":1061835
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6a45323753c4ca3d7c01787b2756983e",
+    "wof:geomhash":"b9ccecb284a2a0831eed32d5ecc63958",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"Q\u0259b\u0259l\u0259",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/49/85668549.geojson
+++ b/data/856/685/49/85668549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116362,
-    "geom:area_square_m":1084799464.993237,
+    "geom:area_square_m":1084799256.162304,
     "geom:bbox":"47.293386,40.829581,47.739121,41.268733",
     "geom:latitude":41.066815,
     "geom:longitude":47.517911,
@@ -319,17 +319,19 @@
         "gn:id":584742,
         "gp:id":20070250,
         "hasc:id":"AZ.OG",
+        "iso:code":"AZ-OGU",
         "iso:id":"AZ-OGU",
         "qs_pg:id":550099,
         "unlc:id":"AZ-OGU",
         "wd:id":"Q643989",
         "wk:page":"Oghuz District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4ad289f3adc82d234ebd935c900f323",
+    "wof:geomhash":"05d7da042188a53e94ea94fff8637978",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -345,7 +347,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855732,
+    "wof:lastmodified":1695884357,
     "wof:name":"O\u011fuz",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/57/85668557.geojson
+++ b/data/856/685/57/85668557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.151805,
-    "geom:area_square_m":1409999523.110991,
+    "geom:area_square_m":1410000145.556671,
     "geom:bbox":"46.634342,40.923715,47.195094,41.585723",
     "geom:latitude":41.308754,
     "geom:longitude":46.867851,
@@ -146,15 +146,17 @@
         "gn:id":586290,
         "gp:id":20070229,
         "hasc:id":"AZ.QX",
+        "iso:code":"AZ-QAX",
         "iso:id":"AZ-QAX",
         "qs_pg:id":1014923,
         "unlc:id":"AZ-QAX"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d005722d3caf45342c8233d29b42e134",
+    "wof:geomhash":"5837a36e62f117e86dc5ce20026b39b8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497570,
+    "wof:lastmodified":1695884854,
     "wof:name":"Qax",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/65/85668565.geojson
+++ b/data/856/685/65/85668565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.249012,
-    "geom:area_square_m":2320224269.14728,
+    "geom:area_square_m":2320223936.728558,
     "geom:bbox":"46.817994,40.777806,47.61966,41.466609",
     "geom:latitude":41.101496,
     "geom:longitude":47.164898,
@@ -84,14 +84,16 @@
         "fips:code":"AJ47",
         "gp:id":20070246,
         "hasc:id":"AZ.SK",
+        "iso:code":"AZ-SAK",
         "iso:id":"AZ-SAK",
         "qs_pg:id":32219
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"373cd2bf729bdcf93fcaa0e6b70902cc",
+    "wof:geomhash":"d50adf1e05606ac29cfc2036532a9462",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +109,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884738,
     "wof:name":"\u015e\u0259ki",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/685/71/85668571.geojson
+++ b/data/856/685/71/85668571.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279301,
-    "geom:area_square_m":2598838637.301364,
+    "geom:area_square_m":2598839030.47713,
     "geom:bbox":"47.985143,40.889401,48.835733,41.496695",
     "geom:latitude":41.192447,
     "geom:longitude":48.471895,
@@ -321,17 +321,19 @@
         "gn:id":585786,
         "gp:id":20070232,
         "hasc:id":"AZ.QB",
+        "iso:code":"AZ-QBA",
         "iso:id":"AZ-QBA",
         "qs_pg:id":1189263,
         "unlc:id":"AZ-QBA",
         "wd:id":"Q457499",
         "wk:page":"Quba District (Azerbaijan)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2470ace4bb58cb5d9b3d687a6df5e576",
+    "wof:geomhash":"e2108871e0b57b734f7a996792c9e5f3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855732,
+    "wof:lastmodified":1695884854,
     "wof:name":"Quba",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/685/77/85668577.geojson
+++ b/data/856/685/77/85668577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166305,
-    "geom:area_square_m":1541301201.403419,
+    "geom:area_square_m":1541300596.481266,
     "geom:bbox":"47.853507,41.180377,48.675844,41.741452",
     "geom:latitude":41.451295,
     "geom:longitude":48.28902,
@@ -320,17 +320,19 @@
         "gn:id":585749,
         "gp:id":20070234,
         "hasc:id":"AZ.QR",
+        "iso:code":"AZ-QUS",
         "iso:id":"AZ-QUS",
         "qs_pg:id":952227,
         "unlc:id":"AZ-QUS",
         "wd:id":"Q386506",
         "wk:page":"Qusar District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"618b9d1d7409457dfb7d3de1ea2d35e7",
+    "wof:geomhash":"509d7b4c6f46e9c9ed15944d52b21f8a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855732,
+    "wof:lastmodified":1695884854,
     "wof:name":"Qusar",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/685/91/85668591.geojson
+++ b/data/856/685/91/85668591.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109147,
-    "geom:area_square_m":1009878374.035641,
+    "geom:area_square_m":1009877689.625619,
     "geom:bbox":"48.532563,41.351025,49.076479,41.847914",
     "geom:latitude":41.559399,
     "geom:longitude":48.779571,
@@ -308,17 +308,19 @@
         "gn:id":586001,
         "gp:id":20070221,
         "hasc:id":"AZ.XZ",
+        "iso:code":"AZ-XAC",
         "iso:id":"AZ-XAC",
         "qs_pg:id":500534,
         "unlc:id":"AZ-XAC",
         "wd:id":"Q6398826",
         "wk:page":"Khachmaz District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7d68f487455cdb2a8a8c7a891cd88ab",
+    "wof:geomhash":"66b845f27f4d30e633df988cb8fdd024",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855731,
+    "wof:lastmodified":1695884357,
     "wof:name":"Xa\u00e7maz",
     "wof:parent_id":1108808623,
     "wof:placetype":"region",

--- a/data/856/686/01/85668601.geojson
+++ b/data/856/686/01/85668601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147388,
-    "geom:area_square_m":1363258461.213051,
+    "geom:area_square_m":1363258339.559977,
     "geom:bbox":"46.298059,41.370127,47.030975,41.856911",
     "geom:latitude":41.580404,
     "geom:longitude":46.676212,
@@ -322,16 +322,18 @@
         "gn:id":584604,
         "gp:id":20070254,
         "hasc:id":"AZ.ZQ",
+        "iso:code":"AZ-ZAQ",
         "iso:id":"AZ-ZAQ",
         "qs_pg:id":202013,
         "wd:id":"Q147553",
         "wk:page":"Zaqatala District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de9c2c190078475d8e705f912f3e7aeb",
+    "wof:geomhash":"df011805f1a9021a596a3978bdf6f846",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855725,
+    "wof:lastmodified":1695884853,
     "wof:name":"Zaqatala",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/686/11/85668611.geojson
+++ b/data/856/686/11/85668611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157386,
-    "geom:area_square_m":1498037135.369887,
+    "geom:area_square_m":1498037073.651101,
     "geom:bbox":"46.684992,39.395641,47.349896,39.897906",
     "geom:latitude":39.667674,
     "geom:longitude":47.004931,
@@ -152,14 +152,16 @@
         "gn:id":409423,
         "gp:id":20070259,
         "hasc:id":"AZ.XD",
+        "iso:code":"AZ-XVD",
         "iso:id":"AZ-XVD",
         "qs_pg:id":59492
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"168db51c22a4119d45192cb79f3b77ff",
+    "wof:geomhash":"ee9ed7b9bcd3120d9f61a55aeaa2d345",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -175,7 +177,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"Xocav\u0259nd",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/21/85668621.geojson
+++ b/data/856/686/21/85668621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187509,
-    "geom:area_square_m":1782996104.10108,
+    "geom:area_square_m":1782995910.395563,
     "geom:bbox":"45.917056,39.454828,46.756361,39.960807",
     "geom:latitude":39.735667,
     "geom:longitude":46.347243,
@@ -336,14 +336,16 @@
         "gn:id":147626,
         "gp:id":20070262,
         "hasc:id":"AZ.LC",
+        "iso:code":"AZ-LAC",
         "iso:id":"AZ-LAC",
         "qs_pg:id":32221
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fe5307f78dea455dd08dc6830e286336",
+    "wof:geomhash":"8086bfe9d7c49e0e7ac29dfc31436566",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497567,
+    "wof:lastmodified":1695884853,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/29/85668629.geojson
+++ b/data/856/686/29/85668629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085732,
-    "geom:area_square_m":819747872.712544,
+    "geom:area_square_m":819748033.61191,
     "geom:bbox":"46.381072,39.120703,46.824353,39.526391",
     "geom:latitude":39.350608,
     "geom:longitude":46.621814,
@@ -146,15 +146,17 @@
         "gn:id":147694,
         "gp:id":20070233,
         "hasc:id":"AZ.QD",
+        "iso:code":"AZ-QBI",
         "iso:id":"AZ-QBI",
         "qs_pg:id":1172848,
         "unlc:id":"AZ-QBI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b35d766edb66333875941ff1c4f421c",
+    "wof:geomhash":"811f7f550c26edcdb48143b6e63692f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -170,7 +172,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497566,
+    "wof:lastmodified":1695884853,
     "wof:name":"Qubadli",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/43/85668643.geojson
+++ b/data/856/686/43/85668643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03125,
-    "geom:area_square_m":297302860.182473,
+    "geom:area_square_m":297302796.370649,
     "geom:bbox":"46.554041,39.601918,46.801093,39.78535",
     "geom:latitude":39.699947,
     "geom:longitude":46.662897,
@@ -251,16 +251,18 @@
         "gn:id":409419,
         "gp:id":20070264,
         "hasc:id":"AZ.SU",
+        "iso:code":"AZ-SUS",
         "iso:id":"AZ-SUS",
         "qs_pg:id":500533,
         "wd:id":"Q388960",
         "wk:page":"Shusha District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4a8a07724d458b02c04930ad0499cda",
+    "wof:geomhash":"bb0dbb626f6b4e9163509097dbdab21e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855724,
+    "wof:lastmodified":1695884357,
     "wof:name":"\u015eu\u015fa",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/53/85668653.geojson
+++ b/data/856/686/53/85668653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.13562,
-    "geom:area_square_m":1279040771.133141,
+    "geom:area_square_m":1279040974.533582,
     "geom:bbox":"46.497293,40.106687,47.106029,40.502876",
     "geom:latitude":40.296364,
     "geom:longitude":46.808218,
@@ -142,14 +142,16 @@
         "gn:id":409420,
         "gp:id":20070274,
         "hasc:id":"AZ.TA",
+        "iso:code":"AZ-TAR",
         "iso:id":"AZ-TAR",
         "qs_pg:id":245265
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"51b57df78c9c570fdc8f22a91dfaae5f",
+    "wof:geomhash":"a2768cc67e1de8c7ad2e73e65cff8bbb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -165,7 +167,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884738,
     "wof:name":"T\u0259rt\u0259r",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/57/85668657.geojson
+++ b/data/856/686/57/85668657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095897,
-    "geom:area_square_m":909950343.35684,
+    "geom:area_square_m":909950368.786972,
     "geom:bbox":"46.457111,39.655938,46.948759,40.030579",
     "geom:latitude":39.880216,
     "geom:longitude":46.717395,
@@ -155,15 +155,17 @@
         "gn:id":409421,
         "gp:id":20070277,
         "hasc:id":"AZ.XC",
+        "iso:code":"AZ-XCI",
         "iso:id":"AZ-XCI",
         "qs_pg:id":1013385,
         "unlc:id":"AZ-XCI"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c0d69ecc39f4045f77e68aea87cb79b8",
+    "wof:geomhash":"3d3374adff13c7353836206bfd97bbc0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -179,7 +181,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521583,
+    "wof:lastmodified":1695884737,
     "wof:name":"Xocal\u0131",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/59/85668659.geojson
+++ b/data/856/686/59/85668659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072376,
-    "geom:area_square_m":694665070.929124,
+    "geom:area_square_m":694664976.389456,
     "geom:bbox":"46.427856,38.848834,46.887335,39.243301",
     "geom:latitude":39.085067,
     "geom:longitude":46.644829,
@@ -272,15 +272,17 @@
         "gn:id":146900,
         "gp:id":20070255,
         "hasc:id":"AZ.ZG",
+        "iso:code":"AZ-ZAN",
         "iso:id":"AZ-ZAN",
         "qs_pg:id":128257,
         "wd:id":"Q249226"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8a1faa49b803b3a3dccb94494d1bcaa8",
+    "wof:geomhash":"79cf631c3201da94e3fd9c3956e6729a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -296,7 +298,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855723,
+    "wof:lastmodified":1695885138,
     "wof:name":"Z\u0259ngilan",
     "wof:parent_id":1108808607,
     "wof:placetype":"region",

--- a/data/856/686/63/85668663.geojson
+++ b/data/856/686/63/85668663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016255,
-    "geom:area_square_m":154642073.38214,
+    "geom:area_square_m":154642214.486282,
     "geom:bbox":"44.752661,39.633188,44.996216,39.813537",
     "geom:latitude":39.702061,
     "geom:longitude":44.877692,
@@ -198,14 +198,16 @@
         "gn:id":409387,
         "gp:id":-2345767,
         "hasc:id":"AZ.SD",
+        "iso:code":"AZ-SAD",
         "iso:id":"AZ-SAD",
         "wd:id":"Q4404519"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"17487036c77d917eb2ed75a72c57b047",
+    "wof:geomhash":"0b6074957488e593b3794f50a8d7b608",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -221,7 +223,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855725,
+    "wof:lastmodified":1695884738,
     "wof:name":"S\u0259d\u0259r\u0259k",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/65/85668665.geojson
+++ b/data/856/686/65/85668665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102022,
-    "geom:area_square_m":979784804.114614,
+    "geom:area_square_m":979784972.00822,
     "geom:bbox":"45.751766,38.830049,46.143183,39.312839",
     "geom:latitude":39.043031,
     "geom:longitude":45.943032,
@@ -230,15 +230,17 @@
         "gn:id":147365,
         "gp:id":24550719,
         "hasc:id":"AZ.OR",
+        "iso:code":"AZ-ORD",
         "iso:id":"AZ-ORD",
         "qs_pg:id":1062978,
         "unlc:id":"AZ-ORD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2db726d0e00d29746587e05491f66db",
+    "wof:geomhash":"211aa1423336a6ba27a9be3da2aa3b9d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -254,7 +256,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497567,
+    "wof:lastmodified":1695884853,
     "wof:name":"Ordubad",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/67/85668667.geojson
+++ b/data/856/686/67/85668667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090452,
-    "geom:area_square_m":861932854.66219,
+    "geom:area_square_m":861932842.564359,
     "geom:bbox":"44.804744,39.377052,45.316067,39.792971",
     "geom:latitude":39.587785,
     "geom:longitude":45.057668,
@@ -241,15 +241,17 @@
         "fips:code":"AJ79",
         "gp:id":24550720,
         "hasc:id":"AZ.SE",
+        "iso:code":"AZ-SAR",
         "iso:id":"AZ-SAR",
         "qs_pg:id":1237266,
         "wd:id":"Q162411"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"695371c7b0d049889f9399c09e202097",
+    "wof:geomhash":"df97948e2a908f5a595b90064682f283",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -265,7 +267,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855723,
+    "wof:lastmodified":1695884481,
     "wof:name":"\u015e\u0259rur",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/73/85668673.geojson
+++ b/data/856/686/73/85668673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085787,
-    "geom:area_square_m":821614822.780355,
+    "geom:area_square_m":821614944.172458,
     "geom:bbox":"45.278275,38.96227,45.608607,39.534099",
     "geom:latitude":39.2365,
     "geom:longitude":45.436711,
@@ -169,14 +169,16 @@
         "gn:id":7669114,
         "gp:id":24550722,
         "hasc:id":"AZ.BK",
+        "iso:code":"AZ-BAB",
         "iso:id":"AZ-BAB",
         "qs_pg:id":1191260
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cef3f3313971e80bc0c2087a91c56b1f",
+    "wof:geomhash":"1fca68844a44d0608ae64227bb041835",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +194,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521582,
+    "wof:lastmodified":1695884737,
     "wof:name":"Bab\u0259k",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/77/85668677.geojson
+++ b/data/856/686/77/85668677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.104189,
-    "geom:area_square_m":999037947.50955,
+    "geom:area_square_m":999038003.530153,
     "geom:bbox":"45.478141,38.921215,45.942752,39.360199",
     "geom:latitude":39.153284,
     "geom:longitude":45.705177,
@@ -156,15 +156,17 @@
         "gn:id":148132,
         "gp:id":24550721,
         "hasc:id":"AZ.CF",
+        "iso:code":"AZ-CUL",
         "iso:id":"AZ-CUL",
         "qs_pg:id":954870,
         "unlc:id":"AZ-CUL"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20f162971847359cf72ca648bf406f2c",
+    "wof:geomhash":"59ed35d3f9283c49ede26ec2014bdde3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +182,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497567,
+    "wof:lastmodified":1695884853,
     "wof:name":"Culfa",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/81/85668681.geojson
+++ b/data/856/686/81/85668681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003638,
-    "geom:area_square_m":34855682.754946,
+    "geom:area_square_m":34855328.450731,
     "geom:bbox":"45.346594,39.162941,45.443105,39.243108",
     "geom:latitude":39.206338,
     "geom:longitude":45.408172,
@@ -347,16 +347,18 @@
         "gn:id":147435,
         "gp:id":20070275,
         "hasc:id":"AZ.NX",
+        "iso:code":"AZ-NV",
         "iso:id":"AZ-NV",
         "qs_pg:id":202015,
         "wd:id":"Q131083",
         "wk:page":"Nakhchivan Autonomous Republic"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f7789ecc522d93eccd35eac63f5d6fe",
+    "wof:geomhash":"a63ff39267ac2f8e2505976c27b511b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -372,7 +374,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855724,
+    "wof:lastmodified":1695884357,
     "wof:name":"Nax\u00e7\u0131van",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/83/85668683.geojson
+++ b/data/856/686/83/85668683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090996,
-    "geom:area_square_m":868955966.861233,
+    "geom:area_square_m":868955905.245107,
     "geom:bbox":"45.379212,39.273208,45.832849,39.598484",
     "geom:latitude":39.441188,
     "geom:longitude":45.631808,
@@ -205,14 +205,16 @@
         "gn:id":147212,
         "gp:id":24550718,
         "hasc:id":"AZ.SH",
+        "iso:code":"AZ-SAH",
         "iso:id":"AZ-SAH",
         "qs_pg:id":1191259
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"009a8a0d68b592074267e844580017ec",
+    "wof:geomhash":"1795786492fdfcb60b9e6d7c8ef2bc31",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -228,7 +230,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1614892862,
+    "wof:lastmodified":1695884481,
     "wof:name":"\u015eahbuz",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",

--- a/data/856/686/91/85668691.geojson
+++ b/data/856/686/91/85668691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003047,
-    "geom:area_square_m":28935321.315996,
+    "geom:area_square_m":28935321.315993,
     "geom:bbox":"46.7417594292,39.7912336734,46.8266486665,39.868359302",
     "geom:latitude":39.827751,
     "geom:longitude":46.783288,
@@ -371,14 +371,16 @@
         "gn:id":148449,
         "gp:id":20070276,
         "hasc:id":"AZ.XA",
+        "iso:code":"AZ-XA",
         "iso:id":"AZ-XA",
         "qs_pg:id":245328
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9eac1e6d4a18bcee948c136ec065a568",
+    "wof:geomhash":"0268d543ca96caa145b5c51926150f0f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -394,7 +396,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1582332203,
+    "wof:lastmodified":1695884357,
     "wof:name":"Stepanakert",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/686/93/85668693.geojson
+++ b/data/856/686/93/85668693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000478,
-    "geom:area_square_m":4493273.739388,
+    "geom:area_square_m":4493308.779357,
     "geom:bbox":"46.811611,40.495618,46.840887,40.520158",
     "geom:latitude":40.506645,
     "geom:longitude":46.82702,
@@ -269,17 +269,19 @@
         "gn:id":586112,
         "gp:id":20070261,
         "hasc:id":"AZ.NA",
+        "iso:code":"AZ-NA",
         "iso:id":"AZ-NA",
         "qs_pg:id":49485,
         "unlc:id":"AZ-NA",
         "wd:id":"Q330843",
         "wk:page":"Goranboy District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de0087f4ddd172e31c44a167c74b9f66",
+    "wof:geomhash":"46ad76a92775422615311e48c7d90539",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855724,
+    "wof:lastmodified":1695884853,
     "wof:name":"Naftalan",
     "wof:parent_id":1108808609,
     "wof:placetype":"region",

--- a/data/856/686/97/85668697.geojson
+++ b/data/856/686/97/85668697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001237,
-    "geom:area_square_m":11929877.22308,
+    "geom:area_square_m":11929827.500962,
     "geom:bbox":"48.826298,38.72671,48.864023,38.787567",
     "geom:latitude":38.753136,
     "geom:longitude":48.839621,
@@ -265,14 +265,16 @@
         "fips:code":"AJ30",
         "gp:id":20070263,
         "hasc:id":"AZ.LA",
+        "iso:code":"AZ-LA",
         "iso:id":"AZ-LA",
         "qs_pg:id":245193
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b900d31dad7906e7202d0efba6e02c82",
+    "wof:geomhash":"bd712a6decb3b946c6bac3033829815d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -288,7 +290,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497567,
+    "wof:lastmodified":1695884853,
     "wof:name":"Lankaran",
     "wof:parent_id":1108808625,
     "wof:placetype":"region",

--- a/data/856/687/01/85668701.geojson
+++ b/data/856/687/01/85668701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005474,
-    "geom:area_square_m":51908383.420455,
+    "geom:area_square_m":51908237.907865,
     "geom:bbox":"48.896238,39.863788,48.965869,39.995901",
     "geom:latitude":39.930702,
     "geom:longitude":48.930633,
@@ -255,16 +255,18 @@
         "gn:id":147284,
         "gp:id":20070281,
         "hasc:id":"AZ.AB",
+        "iso:code":"AZ-SR",
         "iso:id":"AZ-SR",
         "qs_pg:id":49487,
         "wd:id":"Q382132",
         "wk:page":"Sabirabad District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68de9f182cb6e136cd2217e155160f0c",
+    "wof:geomhash":"f94d949602de7e5749bc7399aa508dc4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -280,7 +282,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855726,
+    "wof:lastmodified":1695884853,
     "wof:name":"Shirvan",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/687/07/85668707.geojson
+++ b/data/856/687/07/85668707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00407,
-    "geom:area_square_m":37868281.520389,
+    "geom:area_square_m":37868489.41545,
     "geom:bbox":"47.147984,41.155475,47.219424,41.241544",
     "geom:latitude":41.193889,
     "geom:longitude":47.184858,
@@ -83,14 +83,16 @@
         "fips:code":"AJ48",
         "gp:id":20070246,
         "hasc:id":"AZ.SA",
+        "iso:code":"AZ-SA",
         "iso:id":"AZ-SA",
         "qs_pg:id":32219
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d7b9cd9161b663ed0951aa8acf66d8bb",
+    "wof:geomhash":"cf888846001b16e49e55f58837ca1b87",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -106,7 +108,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1627521584,
+    "wof:lastmodified":1695884738,
     "wof:name":"\u015e\u0259ki",
     "wof:parent_id":1108808619,
     "wof:placetype":"region",

--- a/data/856/687/11/85668711.geojson
+++ b/data/856/687/11/85668711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000767,
-    "geom:area_square_m":7288478.520176,
+    "geom:area_square_m":7288553.741715,
     "geom:bbox":"46.732998,39.745133,46.776931,39.771823",
     "geom:latitude":39.757705,
     "geom:longitude":46.751358,
@@ -296,15 +296,17 @@
         "gn:id":409419,
         "gp:id":20070264,
         "hasc:id":"AZ.SS",
+        "iso:code":"AZ-SUS",
         "qs_pg:id":500533,
         "wd:id":"Q158903",
         "wk:page":"Shusha"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"559a50768a4be85dd8f85b23cf6b426a",
+    "wof:geomhash":"bedd7ca80486f7b96fc2bfab26073d84",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855726,
+    "wof:lastmodified":1695884481,
     "wof:name":"\u015eu\u015fa",
     "wof:parent_id":1108808615,
     "wof:placetype":"region",

--- a/data/856/687/15/85668715.geojson
+++ b/data/856/687/15/85668715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005466,
-    "geom:area_square_m":51311632.848639,
+    "geom:area_square_m":51311869.937553,
     "geom:bbox":"47.093055,40.569834,47.194347,40.640163",
     "geom:latitude":40.608177,
     "geom:longitude":47.145072,
@@ -324,16 +324,18 @@
         "gn:id":584650,
         "gp:id":20070253,
         "hasc:id":"AZ.YE",
+        "iso:code":"AZ-YE",
         "iso:id":"AZ-YE",
         "qs_pg:id":128256,
         "wd:id":"Q458524",
         "wk:page":"Yevlakh District"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f306a3a5792e16ff5e35cd052bba0330",
+    "wof:geomhash":"3b1ecb0d7c3f7b8d5fd2b26be634cbc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1690855726,
+    "wof:lastmodified":1695884853,
     "wof:name":"Yevlakh",
     "wof:parent_id":1108808627,
     "wof:placetype":"region",

--- a/data/856/687/17/85668717.geojson
+++ b/data/856/687/17/85668717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068426,
-    "geom:area_square_m":654040522.429201,
+    "geom:area_square_m":654041243.394847,
     "geom:bbox":"45.042228,39.182957,45.350127,39.557568",
     "geom:latitude":39.375023,
     "geom:longitude":45.21353,
@@ -92,14 +92,16 @@
         "fips:code":"AJ74",
         "gp:id":24550720,
         "hasc:id":"AZ.KG",
+        "iso:code":"AZ-KAN",
         "iso:id":"AZ-KAN",
         "qs_pg:id":1237266
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AZ",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cb2f791899819c93dbf4323612eb9ee6",
+    "wof:geomhash":"d445f3904785d5d80c39ecf5534a4936",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -115,7 +117,7 @@
     "wof:lang_x_spoken":[
         "aze"
     ],
-    "wof:lastmodified":1636497568,
+    "wof:lastmodified":1695884853,
     "wof:name":"Kangarli",
     "wof:parent_id":1108808617,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.